### PR TITLE
Optimize cell highlight rendering updates

### DIFF
--- a/src/features/game-board/model/hooks/useCell.tsx
+++ b/src/features/game-board/model/hooks/useCell.tsx
@@ -3,15 +3,15 @@ import { CellProps } from "@entities/cell/model/types";
 import { useSudokuStore } from "@features/game-controls/model/stores";
 import { KeyboardEvent, useCallback, useMemo } from "react";
 
+const EMPTY_HIGHLIGHT = { selected: false, related: false, sameValue: false } as const;
+
 export const useCell = ({ cell, row, col, onSelect }: CellProps) => {
-  const highlightedCells = useSudokuStore((state) => state.highlightedCells);
   const gameMode = useSudokuStore((state) => state.gameMode);
   const isNoteMode = useSudokuStore((state) => state.isNoteMode);
   const timerActive = useSudokuStore((state) => state.timerActive);
 
   const cellKey = `${row}-${col}`;
-  const EMPTY_HIGHLIGHT = { selected: false, related: false, sameValue: false } as const;
-  const highlight = highlightedCells[cellKey] ?? EMPTY_HIGHLIGHT;
+  const highlight = useSudokuStore((state) => state.highlightedCells[cellKey] ?? EMPTY_HIGHLIGHT);
 
   // 메모화된 스타일 계산
   const borderStyles = useMemo(() => getCellBorderStyles(row, col), [row, col]);

--- a/src/features/game-controls/model/stores/sudokuStore.ts
+++ b/src/features/game-controls/model/stores/sudokuStore.ts
@@ -17,6 +17,7 @@ import {
 } from "@features/game-board/model/utils";
 import {
   calculateHighlights,
+  clearHighlights,
   canFillCell,
   checkGameCompletion,
   findEmptyCells,
@@ -138,7 +139,7 @@ export const useSudokuStore = create<SudokuState & SudokuActions>()(
       resetUserInputs: () => {
         const { board } = get();
         const newBoard = resetUserInputsOptimized(board);
-        const emptyHighlights = createEmptyHighlights();
+        const emptyHighlights = clearHighlights(get().highlightedCells);
 
         set({
           board: newBoard,
@@ -192,13 +193,13 @@ export const useSudokuStore = create<SudokuState & SudokuActions>()(
         const { board } = get();
         const { selectedCell } = get();
         if (!selectedCell) {
-          set({ highlightedCells: createEmptyHighlights() });
+          set({ highlightedCells: clearHighlights(get().highlightedCells) });
           return;
         }
 
         const newBoard = updateSingleCell(board, selectedCell.row, selectedCell.col, { isSelected: false });
 
-        set({ board: newBoard, selectedCell: null, highlightedCells: createEmptyHighlights() });
+        set({ board: newBoard, selectedCell: null, highlightedCells: clearHighlights(get().highlightedCells) });
       },
 
       toggleNote: (value) => {
@@ -300,7 +301,7 @@ export const useSudokuStore = create<SudokuState & SudokuActions>()(
 
       updateHighlights: (row, col) => {
         const { board } = get();
-        const newHighlights = calculateHighlights(board, row, col);
+        const newHighlights = calculateHighlights(board, row, col, get().highlightedCells);
         set({ highlightedCells: newHighlights });
       },
 

--- a/src/features/game-controls/model/utils/__tests__/update.test.ts
+++ b/src/features/game-controls/model/utils/__tests__/update.test.ts
@@ -8,6 +8,7 @@ import {
   calculateHighlights,
   canFillCell,
   checkGameCompletion,
+  clearHighlights,
   findEmptyCells,
   resetUserInputs,
   updateCellNotes,
@@ -150,6 +151,32 @@ describe("update.ts 유틸리티 함수 테스트", () => {
 
       // 같은 값을 가진 셀이 sameValue로 마킹되어야 함
       expect(highlights["1-1"].sameValue).toBe(true);
+    });
+
+    it("변경되지 않은 셀의 하이라이트 객체는 재사용되어야 합니다", () => {
+      const board = createTestBoard();
+
+      const firstHighlights = calculateHighlights(board, 0, 0);
+      const secondHighlights = calculateHighlights(board, 0, 1, firstHighlights);
+
+      expect(secondHighlights["8-8"]).toBe(firstHighlights["8-8"]);
+      expect(secondHighlights["0-0"]).not.toBe(firstHighlights["0-0"]);
+      expect(secondHighlights["0-1"]).not.toBe(firstHighlights["0-1"]);
+    });
+  });
+
+  describe("clearHighlights", () => {
+    it("기존 하이라이트 객체 중 변경되지 않은 항목은 재사용해야 합니다", () => {
+      const board = createTestBoard();
+      const highlights = calculateHighlights(board, 0, 0);
+
+      const cleared = clearHighlights(highlights);
+
+      expect(cleared["0-0"]).not.toBe(highlights["0-0"]);
+      expect(cleared["8-8"]).toBe(highlights["8-8"]);
+      expect(cleared["0-0"].selected).toBe(false);
+      expect(cleared["0-0"].related).toBe(false);
+      expect(cleared["0-0"].sameValue).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure Sudoku cells subscribe to per-cell highlight slices to avoid unnecessary re-renders
- reuse highlight state objects when possible and add utilities/tests to cover the new behaviour
- update the Zustand store to clear and recalculate highlights without recreating unchanged entries

## Testing
- pnpm test --run src/features/game-controls/model/utils/__tests__/update.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db60cc5a2c8327850b3dd451d7f628